### PR TITLE
Separate out funding credits and withdrawing them

### DIFF
--- a/programs/keeper/src/instructions/mod.rs
+++ b/programs/keeper/src/instructions/mod.rs
@@ -1,5 +1,7 @@
 pub use perform_job::*;
 pub use register_job::*;
+pub use withdraw_job_credit::*;
 
 pub mod perform_job;
 pub mod register_job;
+pub mod withdraw_job_credit;

--- a/programs/keeper/src/instructions/perform_job.rs
+++ b/programs/keeper/src/instructions/perform_job.rs
@@ -45,7 +45,6 @@ impl<'info> PerformJob<'info> {
 
 pub fn perform_job<'key, 'accounts, 'remaining, 'info>(
     ctx: Context<'key, 'accounts, 'remaining, 'info, PerformJob<'info>>,
-    job_bump: u8,
     cpi_data: Vec<u8>,
 ) -> Result<()> {
     // verify job instruction tag
@@ -73,8 +72,7 @@ pub fn perform_job<'key, 'accounts, 'remaining, 'info>(
     )?;
 
     // transfer credits
-    let program = &mut ctx.accounts.program;
-    let seeds = &[program.key.as_ref(), &ix_tag.to_le_bytes(), &[job_bump]];
+    let seeds = job_seeds!(&ctx.accounts.job);
     transfer(ctx.accounts.transfer_ctx().with_signer(&[seeds]), 1)?;
 
     Ok(())

--- a/programs/keeper/src/instructions/withdraw_job_credit.rs
+++ b/programs/keeper/src/instructions/withdraw_job_credit.rs
@@ -1,0 +1,54 @@
+use anchor_lang::prelude::*;
+use anchor_spl::associated_token::AssociatedToken;
+use anchor_spl::token::{transfer, Mint, Token, TokenAccount, Transfer};
+
+use crate::error::*;
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct WithdrawJobCredit<'info> {
+    #[account(
+        has_one = credits_mint,
+        has_one = authority,
+    )]
+    pub job: Box<Account<'info, Job>>,
+
+    pub credits_mint: Box<Account<'info, Mint>>,
+
+    pub authority: Signer<'info>,
+
+    #[account(
+        mut,
+        associated_token::authority = job,
+        associated_token::mint = credits_mint,
+    )]
+    pub vault: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        constraint = destination.mint == credits_mint.key(),
+    )]
+    pub destination: Box<Account<'info, TokenAccount>>,
+
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+}
+
+impl<'info> WithdrawJobCredit<'info> {
+    pub fn transfer_ctx(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        let program = self.token_program.to_account_info();
+        let accounts = Transfer {
+            from: self.vault.to_account_info(),
+            to: self.destination.to_account_info(),
+            authority: self.job.to_account_info(),
+        };
+        CpiContext::new(program, accounts)
+    }
+}
+
+pub fn withdraw_job_credit(ctx: Context<WithdrawJobCredit>, amount: u64) -> Result<()> {
+    let seeds = job_seeds!(&ctx.accounts.job);
+    transfer(ctx.accounts.transfer_ctx().with_signer(&[seeds]), amount)?;
+
+    Ok(())
+}

--- a/programs/keeper/src/lib.rs
+++ b/programs/keeper/src/lib.rs
@@ -16,20 +16,18 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 pub mod keeper {
     use super::*;
 
-    pub fn register_job(
-        ctx: Context<RegisterJob>,
-        job_bump: u8,
-        ix_tag: u32,
-        amount: u64,
-    ) -> Result<()> {
-        instructions::register_job(ctx, job_bump, ix_tag, amount)
+    pub fn register_job(ctx: Context<RegisterJob>, job_bump: u8, ix_tag: u32) -> Result<()> {
+        instructions::register_job(ctx, job_bump, ix_tag)
     }
 
     pub fn perform_job<'key, 'accounts, 'remaining, 'info>(
         ctx: Context<'key, 'accounts, 'remaining, 'info, PerformJob<'info>>,
-        job_bump: u8,
         cpi_data: Vec<u8>,
     ) -> Result<()> {
-        instructions::perform_job(ctx, job_bump, cpi_data)
+        instructions::perform_job(ctx, cpi_data)
+    }
+
+    pub fn withdraw_job_credit(ctx: Context<WithdrawJobCredit>, amount: u64) -> Result<()> {
+        instructions::withdraw_job_credit(ctx, amount)
     }
 }

--- a/programs/keeper/src/state/job.rs
+++ b/programs/keeper/src/state/job.rs
@@ -7,10 +7,28 @@ use anchor_lang::prelude::*;
 pub struct Job {
     pub program: Pubkey,
     pub credits_mint: Pubkey,
+    pub authority: Pubkey,
     // todo: unsure how about bundling ix_tag, and later checking it, technically programs are free
     // to decode incoming ix data as they see fit, it doesnt need to be first 4 bytes, though
     // that is the convention
     pub ix_tag: u32,
-    // todo padding
+    pub bump: u8,
+
+    // TODO: padding size
+    padding: [u8; 3],
 }
-const_assert!(size_of::<Job>() == 32 + 32 + 4);
+const_assert!(size_of::<Job>() == 3 * 32 + 4 + 1 + 3);
+
+#[macro_export]
+macro_rules! job_seeds {
+    ( $job:expr ) => {
+        &[
+            $job.authority.as_ref(),
+            $job.program.as_ref(),
+            &$job.ix_tag.to_le_bytes(),
+            &[$job.bump],
+        ]
+    };
+}
+
+pub use job_seeds;

--- a/programs/keeper/tests/program_test/helpers/keeper_requiring_program.rs
+++ b/programs/keeper/tests/program_test/helpers/keeper_requiring_program.rs
@@ -26,7 +26,6 @@ pub enum KeeperRequiringProgramInstruction {
     Update {},
 }
 
-entrypoint!(process_instruction);
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/keeper/tests/test_basic.rs
+++ b/programs/keeper/tests/test_basic.rs
@@ -21,12 +21,14 @@ async fn test_basic() -> Result<(), TransportError> {
 
     /// register job
     let context_argument = &context;
+    let authority = Keypair::new();
     let payer = &context_argument.users[0].key;
     let mint = context_argument.mints[0].pubkey.unwrap();
     let token = context_argument.users[0].token_accounts[0];
     let ix_tag: [u8; 4] = 1u32.to_le_bytes();
     let (job, job_bump) = Pubkey::find_program_address(
         &[
+            &authority.pubkey().as_ref(),
             &context_argument
                 .keeper_requiring_program
                 .program_id
@@ -35,29 +37,41 @@ async fn test_basic() -> Result<(), TransportError> {
         ],
         &context_argument.keeper.program_id,
     );
-    let instructions = vec![Instruction {
-        program_id: context_argument.keeper.program_id,
-        accounts: anchor_lang::ToAccountMetas::to_account_metas(
-            &keeper::accounts::RegisterJob {
-                job,
-                vault: spl_associated_token_account::get_associated_token_address(&job, &mint),
-                program: context_argument.keeper_requiring_program.program_id,
-                deposit_authority: payer.pubkey(),
-                credits_mint: mint,
-                deposit_token: token,
-                system_program: solana_sdk::system_program::id(),
-                token_program: spl_token::id(),
-                associated_token_program: spl_associated_token_account::id(),
-                rent: solana_sdk::sysvar::rent::id(),
-            },
-            None,
-        ),
-        data: anchor_lang::InstructionData::data(&keeper::instruction::RegisterJob {
-            job_bump,
-            ix_tag: 1,
-            amount: 100,
-        }),
-    }];
+    let vault = spl_associated_token_account::get_associated_token_address(&job, &mint);
+    let instructions = vec![
+        Instruction {
+            program_id: context_argument.keeper.program_id,
+            accounts: anchor_lang::ToAccountMetas::to_account_metas(
+                &keeper::accounts::RegisterJob {
+                    job,
+                    vault,
+                    program: context_argument.keeper_requiring_program.program_id,
+                    authority: authority.pubkey(),
+                    payer: payer.pubkey(),
+                    credits_mint: mint,
+                    system_program: solana_sdk::system_program::id(),
+                    token_program: spl_token::id(),
+                    associated_token_program: spl_associated_token_account::id(),
+                    rent: solana_sdk::sysvar::rent::id(),
+                },
+                None,
+            ),
+            data: anchor_lang::InstructionData::data(&keeper::instruction::RegisterJob {
+                job_bump,
+                ix_tag: 1,
+            }),
+        },
+        // Fund the newly created vault with 100 tokens
+        spl_token::instruction::transfer(
+            &spl_token::ID,
+            &token,
+            &vault,
+            &payer.pubkey(),
+            &[&payer.pubkey()],
+            100,
+        )
+        .unwrap(),
+    ];
     context_argument
         .solana
         .process_transaction(&instructions, Some(&[payer]))
@@ -66,14 +80,13 @@ async fn test_basic() -> Result<(), TransportError> {
 
     /// perform job
     let context_argument = &context;
-    let payer = &context_argument.users[0].key;
     let mint = context_argument.mints[0].pubkey.unwrap();
     let instructions = vec![Instruction {
         program_id: context_argument.keeper.program_id,
         accounts: anchor_lang::ToAccountMetas::to_account_metas(
             &keeper::accounts::PerformJob {
                 job,
-                vault: spl_associated_token_account::get_associated_token_address(&job, &mint),
+                vault,
                 program: context_argument.keeper_requiring_program.program_id,
                 keeper_token: token,
                 credits_mint: mint,
@@ -82,7 +95,6 @@ async fn test_basic() -> Result<(), TransportError> {
             None,
         ),
         data: anchor_lang::InstructionData::data(&keeper::instruction::PerformJob {
-            job_bump,
             cpi_data: ix_tag.to_vec(),
         }),
     }];
@@ -91,6 +103,34 @@ async fn test_basic() -> Result<(), TransportError> {
         .process_transaction(&instructions, Some(&[]))
         .await
         .unwrap();
+
+    /// withdraw remaining job credits
+    let balance_before = context_argument.solana.token_account_balance(token).await;
+    let instructions = vec![Instruction {
+        program_id: context_argument.keeper.program_id,
+        accounts: anchor_lang::ToAccountMetas::to_account_metas(
+            &keeper::accounts::WithdrawJobCredit {
+                job,
+                vault,
+                credits_mint: mint,
+                authority: authority.pubkey(),
+                destination: token,
+                token_program: spl_token::id(),
+                associated_token_program: spl_associated_token_account::id(),
+            },
+            None,
+        ),
+        data: anchor_lang::InstructionData::data(&keeper::instruction::WithdrawJobCredit {
+            amount: 99,
+        }),
+    }];
+    context_argument
+        .solana
+        .process_transaction(&instructions, Some(&[&authority]))
+        .await
+        .unwrap();
+    let balance_after = context_argument.solana.token_account_balance(token).await;
+    assert_eq!(balance_after, balance_before + 99);
 
     Ok(())
 }


### PR DESCRIPTION
Funding can just be a regular token transfer to the vault.

Withdrawal needs its own instruction. Withdrawal needs to be guarded by
an authority.